### PR TITLE
Fix Resume and Connect Buttons not being clickable in padding

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -88,30 +88,32 @@ const Hero = () => {
           />
         </div>
         <div className="flex flex-col sm:flex-row gap-6 justify-center">
-          <motion.button
-            whileHover={{ scale: 1.05, boxShadow: "0 0 25px #FF1B8D" }}
-            whileTap={{ scale: 0.95 }}
-            className="px-8 py-4 bg-neon-pink text-white font-press-start text-sm pixel-corners neon-glow"
-            onClick={() => playBeep()}
-          >
-            <a
+          <a
               target="_blank"
               rel="noopener noreferrer"
               href="https://x.com/anni_i29"
             >
-              CONNECT ME
-            </a>
-          </motion.button>
-          <motion.button
-            whileHover={{ scale: 1.05, boxShadow: "0 0 25px #00E5FF" }}
-            whileTap={{ scale: 0.95 }}
-            className="px-12 py-4 bg-neon-cyan text-white font-press-start text-sm pixel-corners neon-glow"
-            onClick={() => playBeep()}
-          >
-            <a href="/AnomlUpdatedResume_006.pdf" download="Anmol_Sah_Resume.pdf">
-              RESUME
-            </a>
-          </motion.button>
+            <motion.button
+              whileHover={{ scale: 1.05, boxShadow: "0 0 25px #FF1B8D" }}
+              whileTap={{ scale: 0.95 }}
+              className="px-8 py-4 bg-neon-pink text-white font-press-start text-sm pixel-corners neon-glow"
+              onClick={() => playBeep()}
+            >
+            
+              CONTACT ME
+            
+            </motion.button>
+          </a>
+          <a href="/AnomlUpdatedResume_006.pdf" download="Anmol_Sah_Resume.pdf">
+            <motion.button
+              whileHover={{ scale: 1.05, boxShadow: "0 0 25px #00E5FF" }}
+              whileTap={{ scale: 0.95 }}
+              className="px-12 py-4 bg-neon-cyan text-white font-press-start text-sm pixel-corners neon-glow"
+              onClick={() => playBeep()}
+            >
+            RESUME
+            </motion.button>
+          </a>
         </div>
       </motion.div>
     </section>

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -89,10 +89,10 @@ const Hero = () => {
         </div>
         <div className="flex flex-col sm:flex-row gap-6 justify-center">
           <a
-              target="_blank"
-              rel="noopener noreferrer"
-              href="https://x.com/anni_i29"
-            >
+            target="_blank"
+            rel="noopener noreferrer"
+            href="https://x.com/anni_i29"
+          >
             <motion.button
               whileHover={{ scale: 1.05, boxShadow: "0 0 25px #FF1B8D" }}
               whileTap={{ scale: 0.95 }}


### PR DESCRIPTION
## Notes
Moved `<a/>` element to wrap the button elements, allowing the links to be clickable in the buttons padding.

Renamed `CONNECT ME` to `CONTACT ME` for a more professional feel.

## Relevant code
```js
// Hero.jsx
<a
  target="_blank"
  rel="noopener noreferrer"
  href="https://x.com/anni_i29"
>
  <motion.button
    whileHover={{ scale: 1.05, boxShadow: "0 0 25px #FF1B8D" }}
    whileTap={{ scale: 0.95 }}
    className="px-8 py-4 bg-neon-pink text-white font-press-start text-sm pixel-corners neon-glow"
    onClick={() => playBeep()}
  >
  
    CONTACT ME
  
  </motion.button>
</a>
<a href="/AnomlUpdatedResume_006.pdf" download="Anmol_Sah_Resume.pdf">
  <motion.button
    whileHover={{ scale: 1.05, boxShadow: "0 0 25px #00E5FF" }}
    whileTap={{ scale: 0.95 }}
    className="px-12 py-4 bg-neon-cyan text-white font-press-start text-sm pixel-corners neon-glow"
    onClick={() => playBeep()}
  >
  RESUME
  </motion.button>
</a>
```